### PR TITLE
Modified updateUser to allow optional input parameters.

### DIFF
--- a/KTClient.inc.php
+++ b/KTClient.inc.php
@@ -793,6 +793,11 @@ class KTClient {
      */
     public function updateUser($userId, $userInfo)
     {
+        // Ensure all fields are correctly set
+        $currentUser = $this->getUserById($userId);
+        unset($currentUser['user_id']);
+        $userInfo = array_merge($currentUser, $userInfo);
+
         $response = $this->executeRequest('update_user', array($userId, $userInfo));
 
         return $response->user_id;


### PR DESCRIPTION
SOAP in php has difficulty with required vs optional fields. All the user fields are defined, therefore they are required. Modified on the client library end to allow the user to only send through a couple of the inputs eg only password and id to update the users password. 
