### PR TITLE
Webservice WSDL update

### DIFF
--- a/KTClient.inc.php
+++ b/KTClient.inc.php
@@ -873,6 +873,7 @@ class KTClient {
     {
         $filter = empty($options['filter']) ? null : $options['filter'];
         unset($options['filter']);
+        $options = $this->validateSqlOptions($options);
 
         $response = $this->executeRequest('get_users', array($filter, $options));
 
@@ -905,6 +906,7 @@ class KTClient {
     {
         $filter = empty($options['filter']) ? null : $options['filter'];
         unset($options['filter']);
+        $options = $this->validateSqlOptions($options);
 
         $response = $this->executeRequest('get_groups', array($filter, $options));
 
@@ -937,10 +939,29 @@ class KTClient {
     {
         $filter = empty($options['filter']) ? null : $options['filter'];
         unset($options['filter']);
+        $options = $this->validateSqlOptions($options);
 
         $response = $this->executeRequest('get_roles', array($filter, $options));
 
         return $this->convertToArray($response->roles);
+    }
+
+    /**
+     * Validates the options passed into one of the list functions. The webservice expects all 3 to be present:
+     *      'orderby' => A field by which to order (must be a legitimate field, e.g. 'name', 'id')
+     *                   Can also specify a direction, e.g. 'name desc',
+     *      'limit' => The maximum number of results to be returned,
+     *      'offset' => The offset from which to start returning results when using a limit.
+     *
+     * @param array $options
+     */
+    private function validateSqlOptions($options)
+    {
+        isset($options['orderby']) or $options['orderby'] = 'id';
+        isset($options['limit']) or $options['limit'] = '1000';
+        isset($options['offset']) or $options['offset'] = '0';
+
+        return $options;
     }
 
     /**
@@ -987,12 +1008,13 @@ class KTClient {
      * @param array $permissions
      *
      * The following format is required for the permissions allocated:
-     *      - if the permission is absent from the list it will be false
+     *      - all permissions must be present in the list
      *      - only the string 'true' will be accepted as true
      * Array (
      *       'groups' => Array (
      *           Array (
      *               'id' => 1,
+     *               'name' => '',
      *               'allocated_permissions' => Array
      *                   (
      *                       read' => 'true',
@@ -1007,10 +1029,13 @@ class KTClient {
      *           ),
      *           Array (
      *               'id' => 5,
+     *               'name' => '',
      *               'allocated_permissions' => Array (
      *                       'read' => 'true',
      *                       'write' => 'true',
      *                       'addFolder' => true,
+     *                       'security' => 'false',
+     *                       'delete' => 'false',
      *                       'workflow' => 'true',
      *                       'folder_rename' => 'true',
      *                       'folder_details' => 'true'
@@ -1020,8 +1045,15 @@ class KTClient {
      *       'roles' => Array (
      *           Array (
      *               'id' => 4,
+     *               'name' => '',
      *               'allocated_permissions' => Array (
      *                       'read' => 'true',
+     *                       'write' => 'false',
+     *                       'addFolder' => false,
+     *                       'security' => 'false',
+     *                       'delete' => 'false',
+     *                       'workflow' => 'false',
+     *                       'folder_rename' => 'false',
      *                       'folder_details' => 'true'
      *                   )
      *           )


### PR DESCRIPTION
The users, groups, roles and permissions functions needed to be updated to remove the "array" datatype as it breaks the wsdl validation in stricter typed languages, in this case, java.

The wsdl now requires all the user/groups/roles options and the permissions list to be present. 
